### PR TITLE
feat: endpoint de login con validación de credenciales

### DIFF
--- a/src/db/db.py
+++ b/src/db/db.py
@@ -1,5 +1,10 @@
-from sqlmodel import create_engine
+from sqlmodel import create_engine, Session
 import os
+from typing import Generator
 
 DATABASE_URL = os.getenv("DATABASE_URL")
 engine = create_engine(DATABASE_URL, echo=True)
+
+def get_session() -> Generator[Session, None, None]:
+    with Session(engine) as session:
+        yield session

--- a/src/dto/login.py
+++ b/src/dto/login.py
@@ -1,0 +1,5 @@
+from pydantic import BaseModel
+
+class LoginRequest(BaseModel):
+    email: str
+    password: str

--- a/src/main.py
+++ b/src/main.py
@@ -5,18 +5,20 @@ from typing import Annotated
 from src.db import engine
 from src.crud import create_user, create_feedback
 from src.dto import UserCreate, FeedbackCreate
+from src.routes import auth
+from src.db.db import get_session
 
 ENVIRONMENT = os.getenv("ENVIRONMENT", "dev")
 dosc_url = "/docs" if ENVIRONMENT != "prod" else None
 app = FastAPI(docs_url=dosc_url, redoc_url=None)
+app.include_router(auth.router)
+
 
 @app.on_event("startup")
 def on_startup():
     SQLModel.metadata.create_all(engine)
 
-def get_session():
-    with Session(engine) as session:
-        yield session
+
 
 @app.post("/sign-in")
 def register_user(user: UserCreate, session: Annotated[Session, Depends(get_session)]):

--- a/src/routes/auth.py
+++ b/src/routes/auth.py
@@ -1,0 +1,23 @@
+from src.dto.login import LoginRequest
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+from src.db.db import get_session
+from src.crud.user_crud import get_user_by_email
+from src.security.security import verify_password, create_jwt_token
+
+
+router = APIRouter()
+
+@router.post("/login")
+def login(datos: LoginRequest, db: Session = Depends(get_session)):
+    usuario = get_user_by_email(db, datos.email)
+
+    if not usuario:
+        raise HTTPException(status_code=401, detail="Usuario no encontrado")
+
+    if not verify_password(datos.password, usuario.password):
+        raise HTTPException(status_code=401, detail="Contraseña incorrecta")
+
+
+    token = create_jwt_token(usuario)
+    return {"access_token": token}


### PR DESCRIPTION
Se ha creado el endpoint /login que permite validar las credenciales del usuario (email y contraseña) y generar un token JWT en caso de ser correctas.