### PR TITLE
feat: add api´s for Dashboard-Admin

### DIFF
--- a/src/routes/admin.py
+++ b/src/routes/admin.py
@@ -15,7 +15,8 @@ def admin_required(user=Depends(get_current_user)):
 @router.get("/user-stats", dependencies=[Depends(admin_required)])
 def user_stats(session: Session = Depends(get_session)):
     total = session.exec(select(func.count()).select_from(User)).one()
-    last_month = datetime.now() - timedelta(days=30)
+    last_month = datetime.now()
+    last_month = last_month.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
     last_month_count = session.exec(
         select(func.count()).select_from(User).where(User.created_at >= last_month)
     ).one()
@@ -48,3 +49,4 @@ def average_session_duration(session: Session = Depends(get_session)):
     avg_duration_str = f"{hours:02}:{minutes:02}:{seconds:02}"
 
     return {"average_duration": avg_duration_str}
+

--- a/src/routes/admin.py
+++ b/src/routes/admin.py
@@ -50,3 +50,16 @@ def average_session_duration(session: Session = Depends(get_session)):
 
     return {"average_duration": avg_duration_str}
 
+@router.get("/users_data", dependencies=[Depends(admin_required)])
+def users_data(session: Session = Depends(get_session)):
+    active_users = session.exec(
+        select(User)
+    ).all()
+    return [{"id": user.id, "username": user.username, "email": user.email, "role": user.role} for user in active_users]
+
+@router.get("/users_feedback", dependencies=[Depends(admin_required)])
+def users_feedback(session: Session = Depends(get_session)):
+    feedbacks = session.exec(
+        select(UserSession).where(UserSession.feedback.is_not(None))
+    ).all()
+    return [{"user_id": feedback.user_id, "feedback": feedback.feedback} for feedback in feedbacks]


### PR DESCRIPTION
Se agregan las funciones:

average-session-duration: para obtener la duración promedio de las sesiones de los usuarios activos.
users_data: para obtener los datos de todos los usuarios registrados.
users_feedback: para obtener los datos de todos los feedbacks realizados por los usuarios.
